### PR TITLE
catch most CTRL-Cs and print user-friendly message

### DIFF
--- a/riseml/__main__.py
+++ b/riseml/__main__.py
@@ -54,6 +54,8 @@ def main():
         except HTTPError as e:
             # all uncaught http errors goes here
             handle_error(str(e))
+        except KeyboardInterrupt:
+            print('\nAborting...')
     else:
         parser.print_usage()
 


### PR DESCRIPTION
This should catch most CTRL-C presses, if the user does not immediately do it, e.g., during script's startup.